### PR TITLE
Make the sass task run on 'darwin' platforms, too.

### DIFF
--- a/tasks/sass.js
+++ b/tasks/sass.js
@@ -45,7 +45,7 @@ module.exports = function(grunt) {
       });
 
       var
-        isWin = process.platform.indexOf('win') == "win32",
+        isWin = process.platform == "win32",
         cmd = isWin ? 'sass.bat' : 'sass';
 
       var sass = grunt.util.spawn({


### PR DESCRIPTION
On Mac the platform is "darwin". According to the nodejs documentation comparing to "win32" is good enough for all windows platforms.

http://nodejs.org/api/process.html#process_process_platform
