### PR TITLE
Fix for removal of helper API in 0.4

### DIFF
--- a/tasks/sass.js
+++ b/tasks/sass.js
@@ -31,8 +31,8 @@ module.exports = function(grunt) {
       var src = el.src;
       var files = grunt.file.expandFiles(src);
       var max = files.map(function (filepath) {
-        return grunt.file.read(filepath)
-      }).join('\n')
+        return grunt.file.read(filepath);
+      }).join('\n');
 
       if (path.extname(src) === '.scss') {
         elArgs.push('--scss');


### PR DESCRIPTION
It seems like the helper API (and therefore the concat helper used by this task) has been removed. I replaced it with a less full-featured bit of code rather than duplicate the old concat helper and now this task works with grunt 0.4 again.

Let me know if there's a better way to do this, I'm not that familiar with grunt internals yet.
