### PR TITLE
Fix test import warning

### DIFF
--- a/test/fixtures/compile.sass
+++ b/test/fixtures/compile.sass
@@ -1,4 +1,4 @@
-@import 'imported'
+@import 'imported.sass'
 
 $blue: #3bbfce
 $margin: 16px

--- a/test/fixtures/compile.scss
+++ b/test/fixtures/compile.scss
@@ -1,4 +1,4 @@
-@import 'imported';
+@import 'imported.scss';
 
 $blue: #3bbfce;
 $margin: 16px;


### PR DESCRIPTION
When running `$ grunt` and using Sass 3.2.6 I was receiving this warning:

```
Running "sass:compile" (sass) task
WARNING: On line 1:
  It's not clear which file to import for '@import "imported"'.
  Candidates:
    imported.sass
    imported.scss
  For now I'll choose imported.sass.
  This will be an error in future versions of Sass.

WARNING: On line 1:
  It's not clear which file to import for '@import "imported"'.
  Candidates:
    imported.sass
    imported.scss
  For now I'll choose imported.sass.
  This will be an error in future versions of Sass.
```

This pull request updates the two compile fixtures to remove that warning.
