### PR TITLE
PR: Add an option for a banner (#45)

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -9,6 +9,9 @@
 
 module.exports = function (grunt) {
   grunt.initConfig({
+    pkg: {
+      name: 'grunt-contrib-sass'
+    },
     jshint: {
       options: {
         jshintrc: '.jshintrc'
@@ -38,6 +41,16 @@ module.exports = function (grunt) {
           'test/tmp/scss.css': ['test/fixtures/compile.scss'],
           'test/tmp/sass.css': ['test/fixtures/compile.sass'],
           'test/tmp/css.css': ['test/fixtures/compile.css']
+        }
+      },
+      compileBanner: {
+        options: {
+          banner: '/* <%= pkg.name %> banner */'
+        },
+        files: {
+          'test/tmp/scss-banner.css': ['test/fixtures/banner.scss'],
+          'test/tmp/sass-banner.css': ['test/fixtures/banner.sass'],
+          'test/tmp/css-banner.css': ['test/fixtures/banner.css']
         }
       }
     }

--- a/README.md
+++ b/README.md
@@ -151,6 +151,15 @@ Default: `false`
 
 Run `sass` with [bundle exec](http://gembundler.com/man/bundle-exec.1.html): `bundle exec sass`.
 
+
+#### banner
+
+Type: `String`  
+
+Prepend the specified string to the output file. Useful for licensing
+information.
+
+
 ### Examples
 
 #### Example config

--- a/tasks/sass.js
+++ b/tasks/sass.js
@@ -12,11 +12,29 @@ module.exports = function (grunt) {
   var dargs = require('dargs');
   var numCPUs = require('os').cpus().length;
 
+  var bannerCallback = function (filename, banner) {
+    var content;
+    grunt.log.verbose.writeln('Writing CSS banner for ' + filename);
+
+    content = grunt.file.read(filename);
+    grunt.file.write(filename, banner + grunt.util.linefeed + content);
+  };
+
   grunt.registerMultiTask('sass', 'Compile Sass to CSS', function () {
     var cb = this.async();
     var options = this.options();
-    var passedArgs = dargs(options, ['bundleExec']);
-    var bundleExec = options.bundleExec;
+    var passedArgs;
+    var bundleExec;
+    var banner;
+
+    // Unset banner option if set
+    if (options.banner) {
+      banner = options.banner;
+      delete options.banner;
+    }
+
+    passedArgs = dargs(options, ['bundleExec']);
+    bundleExec = options.bundleExec;
 
     grunt.verbose.writeflags(options, 'Options');
 
@@ -68,6 +86,11 @@ module.exports = function (grunt) {
             'this task to work. More info:\n' +
             'https://github.com/gruntjs/grunt-contrib-sass'
           );
+        }
+
+        // Callback to insert banner
+        if (banner) {
+          bannerCallback(file.dest, banner);
         }
 
         next(error);

--- a/test/expected/compile-banner.css
+++ b/test/expected/compile-banner.css
@@ -1,0 +1,3 @@
+/* grunt-contrib-sass banner */
+.test {
+  color: green; }

--- a/test/fixtures/banner.css
+++ b/test/fixtures/banner.css
@@ -1,0 +1,3 @@
+.test {
+  color: green;
+}

--- a/test/fixtures/banner.sass
+++ b/test/fixtures/banner.sass
@@ -1,0 +1,2 @@
+.test
+  color: green

--- a/test/fixtures/banner.scss
+++ b/test/fixtures/banner.scss
@@ -1,0 +1,3 @@
+.test {
+  color: green;
+}

--- a/test/sass_test.js
+++ b/test/sass_test.js
@@ -3,15 +3,25 @@ var grunt = require('grunt');
 
 exports.sass = {
   compile: function (test) {
-    test.expect(3);
+    test.expect(6);
 
     var scss = grunt.file.read('test/tmp/scss.css');
     var sass = grunt.file.read('test/tmp/sass.css');
     var css = grunt.file.read('test/tmp/css.css');
     var expected = grunt.file.read('test/expected/compile.css');
+
+    var scssBanner = grunt.file.read('test/tmp/sass-banner.css');
+    var sassBanner = grunt.file.read('test/tmp/scss-banner.css');
+    var cssBanner = grunt.file.read('test/tmp/css-banner.css');
+    var expectedBanner = grunt.file.read('test/expected/compile-banner.css');
+
     test.equal(scss, expected, 'should compile SCSS to CSS');
     test.equal(sass, expected, 'should compile SASS to CSS');
     test.equal(css, expected, 'should compile CSS to CSS');
+
+    test.equal(scssBanner, expectedBanner, 'should compile SCSS with a banner to CSS');
+    test.equal(sassBanner, expectedBanner, 'should compile SASS with a banner to CSS');
+    test.equal(sassBanner, expectedBanner, 'should compile CSS with a banner to CSS');
 
     test.done();
   }


### PR DESCRIPTION
A banner is a string prepended to the specified output file.

This Pull Request closes #45.
Inspired by gruntjs/grunt-contrib-compass#18.
