### PR TITLE
Ignore "_" partial files

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -52,6 +52,13 @@ module.exports = function (grunt) {
           'test/tmp/sass-banner.css': ['test/fixtures/banner.sass'],
           'test/tmp/css-banner.css': ['test/fixtures/banner.css']
         }
+      },
+      ignorePartials: {
+        cwd: 'test/fixtures/partials',
+        src: '*.scss',
+        dest: 'test/tmp',
+        expand: true,
+        ext: '.css'
       }
     }
   });

--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ This plugin requires Grunt `~0.4.0`
 
 If you haven't used [Grunt](http://gruntjs.com/) before, be sure to check out the [Getting Started](http://gruntjs.com/getting-started) guide, as it explains how to create a [Gruntfile](http://gruntjs.com/sample-gruntfile) as well as install and use Grunt plugins. Once you're familiar with that process, you may install this plugin with this command:
 
+Note: Files that begin with "_" are ignored even if they match the globbing pattern. This is done to match the expected [Sass partial behaviour](http://sass-lang.com/documentation/file.SASS_REFERENCE.html#partials).
+
 ```shell
 npm install grunt-contrib-sass --save-dev
 ```

--- a/tasks/sass.js
+++ b/tasks/sass.js
@@ -47,6 +47,10 @@ module.exports = function (grunt) {
         return next();
       }
 
+      if (path.basename(src)[0] === '_') {
+        return next();
+      }
+
       var args = [
         src,
         file.dest,

--- a/test/fixtures/partials/_partial.scss
+++ b/test/fixtures/partials/_partial.scss
@@ -1,0 +1,3 @@
+.foo {
+  color: red;
+}

--- a/test/sass_test.js
+++ b/test/sass_test.js
@@ -3,7 +3,7 @@ var grunt = require('grunt');
 
 exports.sass = {
   compile: function (test) {
-    test.expect(6);
+    test.expect(7);
 
     var scss = grunt.file.read('test/tmp/scss.css');
     var sass = grunt.file.read('test/tmp/sass.css');
@@ -22,6 +22,8 @@ exports.sass = {
     test.equal(scssBanner, expectedBanner, 'should compile SCSS with a banner to CSS');
     test.equal(sassBanner, expectedBanner, 'should compile SASS with a banner to CSS');
     test.equal(sassBanner, expectedBanner, 'should compile CSS with a banner to CSS');
+
+    test.ok(!grunt.file.exists('test/tmp/_partial.css'), 'underscore partial files should be ignored');
 
     test.done();
   }


### PR DESCRIPTION
This matches the expected behaviour in Ruby globbing

Fixes gh-72

Related to https://github.com/sindresorhus/grunt-sass/pull/49
