### PR TITLE
Colorize created path as cyan (using chalk)

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
   },
   "dependencies": {
     "dargs": "~0.1.0",
-    "async": "~0.2.9"
+    "async": "~0.2.9",
+    "chalk": "~0.4.0"
   },
   "devDependencies": {
     "grunt-contrib-clean": "~0.5.0",

--- a/tasks/sass.js
+++ b/tasks/sass.js
@@ -10,6 +10,7 @@ var path = require('path');
 var dargs = require('dargs');
 var numCPUs = require('os').cpus().length;
 var async = require('async');
+var chalk = require('chalk');
 
 module.exports = function (grunt) {
   var bannerCallback = function (filename, banner) {
@@ -95,7 +96,7 @@ module.exports = function (grunt) {
           bannerCallback(file.dest, banner);
         }
 
-        grunt.log.writeln('File "' + file.dest + '" created.');
+        grunt.log.writeln('File ' + chalk.cyan(file.dest) + ' created.');
         next(error);
       });
     }, cb);


### PR DESCRIPTION
- Add [chalk](https://github.com/sindresorhus/chalk) as a dependency.
- Output the name of the files that have been created colorized in cyan and without quotes, which is arguably more readable.

The format will become unified with `grunt-contrib-less` and `grunt-contrib-coffee` (see https://github.com/gruntjs/grunt-contrib-coffee/pull/79), and hopefully with `grunt-contrib-handlebars` (https://github.com/gruntjs/grunt-contrib-handlebars/pull/87).
