### PR TITLE
Add option to specify file encoding

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,11 @@ Default: `false`
 
 Run `sass` with [bundle exec](http://gembundler.com/man/bundle-exec.1.html): `bundle exec sass`.
 
+#### encoding
+
+Type: `String`
+
+Forces `sass` to compile files with the specified encoding
 
 #### banner
 

--- a/docs/sass-options.md
+++ b/docs/sass-options.md
@@ -123,7 +123,13 @@ Run `sass` with [bundle exec](http://gembundler.com/man/bundle-exec.1.html): `bu
 
 ## banner
 
-Type: `String`  
+Type: `String`
+
+## encoding
+
+Type: `String`
+
+Forces `sass` to compile files with the specified encoding
 
 Prepend the specified string to the output file. Useful for licensing information.
 

--- a/tasks/sass.js
+++ b/tasks/sass.js
@@ -26,6 +26,7 @@ module.exports = function (grunt) {
     var options = this.options();
     var passedArgs;
     var bundleExec;
+    var encoding;
     var banner;
 
     // Unset banner option if set
@@ -34,8 +35,9 @@ module.exports = function (grunt) {
       delete options.banner;
     }
 
-    passedArgs = dargs(options, ['bundleExec']);
+    passedArgs = dargs(options, ['bundleExec', 'encoding']);
     bundleExec = options.bundleExec;
+    encoding = options.encoding;
 
     async.eachLimit(this.files, numCPUs, function (file, next) {
       var src = file.src[0];
@@ -66,6 +68,10 @@ module.exports = function (grunt) {
 
       if (bundleExec) {
         args.unshift('bundle', 'exec');
+      }
+
+      if (encoding) {
+        args.push('-E', encoding);
       }
 
       // If we're compiling scss or css files


### PR DESCRIPTION
Hi, this just jumped to me and hope it is useful.

Recently when trying to integrate [sass-mq](https://github.com/guardian/sass-mq) to my project, I received the following error:

```
Running "sass:dev" (sass) task
Syntax error: Invalid US-ASCII character "\xE2"
        on line 155 of /Users/jeduan/Code/cadenadeoracion/bower_components/sass-mq/_mq.scss
        from line 7 of assets/sass/style.scss
  Use --trace for backtrace.
```

A quick googling reveals that the sass cli has the -E option to specify an encoding.

Using said option did make the problem go away, but it wasn't exposed in grunt-contrib-sass, so this pull request exposes the option.
