### PR TITLE
Fix regression in bundler support

### DIFF
--- a/tasks/sass.js
+++ b/tasks/sass.js
@@ -59,8 +59,11 @@ module.exports = function (grunt) {
         '--load-path', path.dirname(src)
       ].concat(passedArgs);
 
+      var bin = 'sass';
+
       if (bundleExec) {
-        args.unshift('bundle', 'exec');
+        bin = 'bundle';
+        args.unshift('exec', 'sass');
       }
 
       // If we're compiling scss or css files
@@ -71,7 +74,7 @@ module.exports = function (grunt) {
       // Make sure grunt creates the destination folders
       grunt.file.write(file.dest, '');
 
-      var cp = spawn('sass', args, {stdio: 'inherit'});
+      var cp = spawn(bin, args, {stdio: 'inherit'});
 
       cp.on('error', function (err) {
         grunt.warn(err);


### PR DESCRIPTION
Commit 35ad9cd45e73 introduced a regression that breaks bundler support. This occurs because rather than spawning `bundle exec sass ...` it would now spawn `sass bundle exec ...`.
