### PR TITLE
Only create destination folders if they do not already exist

### DIFF
--- a/tasks/sass.js
+++ b/tasks/sass.js
@@ -81,8 +81,10 @@ module.exports = function (grunt) {
         args.push('--scss');
       }
 
-      // Make sure grunt creates the destination folders
-      grunt.file.write(file.dest, '');
+      // Make sure grunt creates the destination folders if they don't exist
+      if(!grunt.file.exists(file.dest)) {
+        grunt.file.write(file.dest, '');
+      }
 
       var cp = spawn(bin, args, {stdio: 'inherit'});
 


### PR DESCRIPTION
Fixes gruntjs/grunt-contrib-sass#66

Only create destination folders if they do not already exist. The change prevents a previously created CSS file being overwritten by an empty one and then this change being detected by a live reloader reloading a blank CSS file.
