### PR TITLE
Update README (Sass 3.3 was released)

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Default: `false`
 
 Enable Source Maps.
 
-**Requires Sass 3.3.0, which can be installed with `gem install sass --pre`**
+**Requires Sass 3.3.0.**
 
 
 #### trace


### PR DESCRIPTION
So it can be installed without the special `--pre` flag.
