### PR TITLE
option to stop execution if file does not exist

### DIFF
--- a/tasks/sass.js
+++ b/tasks/sass.js
@@ -55,8 +55,16 @@ module.exports = function (grunt) {
       }
 
       if (!grunt.file.exists(src)) {
-        grunt.log.warn('Source file "' + src + '" not found.');
-        return next();
+        if (options.stopOnError) {
+          // if file does not exist but option stopOnError is set, stop
+          // execution
+          grunt.warn('Source file "' + src + '" not found.');
+        } else {
+          // if option stopOnError has not been set or has been set to false, 
+          // log error message and continue execution
+          grunt.log.warn('Source file "' + src + '" not found.');
+          return next();
+        }
       }
 
       if (path.basename(src)[0] === '_') {


### PR DESCRIPTION
Hello,

We use grunt and grunt sass for the deployment of our css code but the grunt sass plugin does not stop the execution if one of the pathes is wrong. This is problematic for us, as we use a bash script that stops if we get an error code. But as grunt sass does not send us an error code we can not stop the export process at this point. We use several other plugins like grunt jshint and grunt require js and they all halt if there is an error, which is exactly what we need.

This commit includes a new option that can be set, it's called stopOnError, if set to true and a file does not exist, it calls grunt.warn instead of grunt.log.warn. This change does not introduce an bc break as you have to set the option to change the behavior of grunt sass.

Our options part now looks like this:

```
    sass: {
        options: {
            unixNewlines: true,
            trace: true,
            quiet: false,
            stopOnError: true
        },
```

Would you consider including our modifications in your repository?

If this change gets accepted I could also update the documentation afterwards.
