### PR TITLE
fix TypeError if node cannot read cpu's

### DIFF
--- a/tasks/sass.js
+++ b/tasks/sass.js
@@ -8,7 +8,7 @@
 'use strict';
 var path = require('path');
 var dargs = require('dargs');
-var numCPUs = require('os').cpus().length;
+var numCPUs = 1;
 var async = require('async');
 var chalk = require('chalk');
 var spawn = require('win-spawn');
@@ -37,6 +37,10 @@ module.exports = function (grunt) {
         '\nYou need to have Ruby and Sass installed and in your PATH for this task to work.\n' +
         'More info: https://github.com/gruntjs/grunt-contrib-sass\n'
       );
+    }
+
+    if (typeof require('os').cpus() !== "undefined") {
+      numCPUs = require('os').cpus().length;
     }
 
     // Unset banner option if set


### PR DESCRIPTION
in our virtual server (Virtuozzo-based), node.js can't access os.cpus(), so it returns undefined and can't compile. 
