### PR TITLE
Log sass command when --verbose argument is set

### DIFF
--- a/tasks/sass.js
+++ b/tasks/sass.js
@@ -99,6 +99,8 @@ module.exports = function (grunt) {
         grunt.file.write(file.dest, '');
       }
 
+      grunt.verbose.writeln('Command: ' + bin + ' ' + args.join(' '));
+
       var cp = spawn(bin, args, {stdio: 'inherit'});
 
       cp.on('error', function (err) {


### PR DESCRIPTION
Related to issue #135.

As discussed with @sindesorhus it might be useful to log the full sass command when running grunt in verbose mode. It's useful to debug stuff or just to see what's going on while the task runs.

I don't know if the maintainers want to add tests for this, I could add those on the PR as well.
