### PR TITLE
Fix `precision` option default value

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Output style. Can be `nested`, `compact`, `compressed`, `expanded`.
 #### precision
 
 Type: `Number`  
-Default: `3`
+Default: `5`
 
 How many digits of precision to use when outputting decimal numbers.
 

--- a/docs/sass-options.md
+++ b/docs/sass-options.md
@@ -51,7 +51,7 @@ Output style. Can be `nested`, `compact`, `compressed`, `expanded`.
 ## precision
 
 Type: `Number`  
-Default: `3`
+Default: `5`
 
 How many digits of precision to use when outputting decimal numbers.
 


### PR DESCRIPTION
Sass v3.2 or later outputs decimal numbers with 5 digits after point.

See also: https://github.com/sass/sass/commit/edc2634ba08881ceec5aa1835f9e0284e781ffa9
