### PR TITLE
Fix and improve syntax checking (`check` option)

### DIFF
--- a/tasks/sass.js
+++ b/tasks/sass.js
@@ -31,6 +31,50 @@ module.exports = function (grunt) {
     }
   };
 
+  var checkFiles = function (files, options, cb) {
+    var failCount = 0;
+    var filesToCheck = files.filter(function (src) {
+      return path.basename(src)[0] !== '_' && grunt.file.exists(src);
+    });
+
+    async.eachLimit(filesToCheck, numCPUs, function (src, next) {
+      var bin;
+      var args;
+
+      if (options.bundleExec) {
+        bin = 'bundle';
+        args = ['exec', 'sass', '--check', src];
+      } else {
+        bin = 'sass';
+        args = ['--check', src];
+      }
+
+      grunt.verbose.writeln('Command: ' + bin + ' ' + args.join(' '));
+
+      grunt.verbose.writeln('Checking file ' + chalk.cyan(src) + ' syntax.');
+      spawn(bin, args, { stdio: 'inherit' })
+        .on('error', grunt.warn)
+        .on('close', function (code) {
+          if (code > 0) {
+            ++failCount;
+            grunt.log.error('Checking file ' + chalk.cyan(src) + ' - ' + chalk.red('failed') + '.');
+          } else {
+            grunt.verbose.ok('Checking file ' + chalk.cyan(src) + ' - ' + chalk.green('passed') + '.');
+          }
+
+          next();
+        });
+    }, function () {
+      if (failCount > 0) {
+        grunt.warn('Sass check failed for ' + failCount + ' files.')
+      } else {
+        grunt.log.ok('All ' + chalk.cyan(filesToCheck.length) + ' files passed.')
+      }
+
+      cb();
+    });
+  };
+
   grunt.registerMultiTask('sass', 'Compile Sass to CSS', function () {
     var cb = this.async();
     var options = this.options();
@@ -46,6 +90,11 @@ module.exports = function (grunt) {
       checkBinary('sass',
         'You need to have Ruby and Sass installed and in your PATH for this task to work.'
       );
+    }
+
+    if (options.check) {
+      checkFiles(this.filesSrc, options, cb);
+      return;
     }
 
     // Unset banner option if set


### PR DESCRIPTION
Syntax checking via the `check` option (`sass --check ...`) works like a charm now. This PR fixes #141. 
- Checking goes its own code path abstracted in a separate function, improving maintainability, increasing execution speed, and keeping the rest of the code clean.
- Useful default and verbose logging.
