### PR TITLE
First check code with jshint upon running npm/grunt test

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -82,11 +82,12 @@ module.exports = function (grunt) {
 
   grunt.registerTask('mkdir', grunt.file.mkdir);
   grunt.registerTask('test', [
+    'jshint',
     'clean',
     'mkdir:tmp',
     'sass',
     'nodeunit',
     'clean'
   ]);
-  grunt.registerTask('default', ['jshint', 'test', 'build-contrib']);
+  grunt.registerTask('default', ['test', 'build-contrib']);
 };


### PR DESCRIPTION
Motivation is shortly outlined in [this comment](https://github.com/gruntjs/grunt-contrib-sass/commit/84379569d9c5b69dd5cefd7eb2410588c1f55976#commitcomment-7504249).
