### PR TITLE
Made skipping files prefixed with an underscore optional

### DIFF
--- a/tasks/sass.js
+++ b/tasks/sass.js
@@ -30,6 +30,7 @@ module.exports = function (grunt) {
   grunt.registerMultiTask('sass', 'Compile Sass to CSS', function () {
     var cb = this.async();
     var options = this.options();
+    var underscore;
     var passedArgs;
 
     if (options.bundleExec) {
@@ -48,6 +49,11 @@ module.exports = function (grunt) {
       return;
     }
 
+    if (options.underscore) {
+      underscore = options.underscore;
+      delete options.underscore;
+    }
+
     passedArgs = dargs(options, ['bundleExec', 'banner']);
 
     async.eachLimit(this.files, concurrencyCount, function (file, next) {
@@ -62,7 +68,7 @@ module.exports = function (grunt) {
         return next();
       }
 
-      if (path.basename(src)[0] === '_') {
+      if (path.basename(src)[0] === '_' && !underscore) {
         return next();
       }
 


### PR DESCRIPTION
Self explanatory. I have several projects that start with an _filename.scss. This is a small update to make this optional so you can choose to use them or not. By default it skips them. If you set

```
{
  options: {
    underscore: true
  }
}
```

Then it will not skip the files.
