### PR TITLE
Improve handling of invalid files

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,14 @@ Default: `false`
 
 Only compile changed files.
 
+
+#### stopOnError
+
+Type: `Boolean`  
+Default: `false`
+
+If a file fails to compile, exit immediately.
+
 ### Examples
 
 #### Example config
@@ -275,4 +283,4 @@ grunt.initConfig({
 
 Task submitted by [Sindre Sorhus](https://github.com/sindresorhus)
 
-*This file was generated on Fri Mar 18 2016 19:07:34.*
+*This file was generated on Wed Jul 27 2016 20:58:04.*

--- a/docs/sass-options.md
+++ b/docs/sass-options.md
@@ -132,3 +132,11 @@ Type: `Boolean`
 Default: `false`
 
 Only compile changed files.
+
+
+## stopOnError
+
+Type: `Boolean`  
+Default: `false`
+
+If a file fails to compile, exit immediately.

--- a/tasks/lib/check.js
+++ b/tasks/lib/check.js
@@ -18,7 +18,7 @@ module.exports = function (files, options, cb) {
     var args;
 
     var passedArgs = dargs(options, {
-      includes: ['loadPath'],
+      includes: ['loadPath', 'cacheLocation', 'noCache', 'update'],
       ignoreFalse: true
     });
 


### PR DESCRIPTION
I made two small changes which improved the handling of invalid SASS files during build:
1. Made options "cacheLocation", "update", "noCache" available to check task (which allows e.g. to use the same cache as the actual compile task)
2. Added the option "stopOnError" which avoids writing broken code (including error message) into compiled CSS file
